### PR TITLE
fix: command install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ JCloud 에서 VS-Code 기반 Web-IDE 를 제공하기 위한 프로젝트 입니
 ```
 $ git clone https://github.com/hyunchan-park/JCode.git
 $ cd JCode
-$ install.sh
+$ ./install.sh
 ```
 
 3. JCloud 에서 제공하는 주소 및 포트 번호를 통해 JCode 접속  


### PR DESCRIPTION
사소하긴 하지만.. install.sh 실행을 위해서 sh install.sh 또는 ./install.sh  또는 bash install.sh 커맨드를 사용할 수 있는데 sh install.sh 사용시 install.sh의 num=`$RANDOM ...` 부분에서 syntax error가 발생. 
혼동을 줄이기 위해 ./install.sh로 써두면 더 좋아보입니다.